### PR TITLE
Firefox compatibility bugs fixes

### DIFF
--- a/frontend/src/vue/components/Input.vue
+++ b/frontend/src/vue/components/Input.vue
@@ -36,6 +36,10 @@
     }
     .input::placeholder {
         color: $tip;
+        @-moz-document url-prefix() {
+            opacity: 1;
+        }
+        
     }
     .input:-moz-ui-invalid {
         box-shadow: none;


### PR DESCRIPTION
## Changes
- Resolved #30 - inputs don't have red border around them anymore in Firefox,
- Resolved #33 - placeholder color in Firefox is the same as in Chrome now.
